### PR TITLE
Return openURL promise

### DIFF
--- a/AKCommunications.js
+++ b/AKCommunications.js
@@ -189,7 +189,7 @@ const LaunchURL = function(url) {
 		if(!supported) {
 			console.log('Can\'t handle url: ' + url);
 		} else {
-			Linking.openURL(url)
+			return Linking.openURL(url)
 			.catch(err => {
 				if(url.includes('telprompt')) {
 					// telprompt was cancelled and Linking openURL method sees this as an error


### PR DESCRIPTION
To avoid "Warning: a promise was created in a handler but was not returned from it".

http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it
https://facebook.github.io/react-native/docs/linking.html#opening-external-links